### PR TITLE
Facu | PaletteManager y PaletteObject agregados

### DIFF
--- a/Assets/Resources/Palettes.meta
+++ b/Assets/Resources/Palettes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 384eadc038ad8f8418d5053bba117dfc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Palettes/MyOtherPalette.asset
+++ b/Assets/Resources/Palettes/MyOtherPalette.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 71260934f5d4f6645adbec10fae4570c, type: 3}
+  m_Name: MyOtherPalette
+  m_EditorClassIdentifier: 
+  content:
+  - {fileID: 6818101767587472513, guid: 8e1537e27c322e248a88e7c72926bdb2, type: 3}
+  - {fileID: 7636077560631635882, guid: 63f709e9738af804e98873a9a9522325, type: 3}
+  - {fileID: 7262621511279715645, guid: c544cdf1d35a1d648b1e713ed30428a9, type: 3}
+  paletteName: MyOtherPalette

--- a/Assets/Resources/Palettes/MyOtherPalette.asset.meta
+++ b/Assets/Resources/Palettes/MyOtherPalette.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4301b743f52ca934cb507fda01cf0d8d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Palettes/MyPalette.asset
+++ b/Assets/Resources/Palettes/MyPalette.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 71260934f5d4f6645adbec10fae4570c, type: 3}
+  m_Name: MyPalette
+  m_EditorClassIdentifier: 
+  content: []
+  paletteName: MyPalette

--- a/Assets/Resources/Palettes/MyPalette.asset.meta
+++ b/Assets/Resources/Palettes/MyPalette.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e1253bd4e98f50f47ab3e4f1630af247
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Facu.unity
+++ b/Assets/Scenes/Facu.unity
@@ -50,12 +50,11 @@ LightmapSettings:
     m_BounceScale: 1
     m_IndirectOutputScale: 1
     m_AlbedoBoost: 1
-    m_TemporalCoherenceThreshold: 1
     m_EnvironmentLightingMode: 0
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    serializedVersion: 10
+    serializedVersion: 12
     m_Resolution: 2
     m_BakeResolution: 40
     m_AtlasSize: 1024
@@ -63,6 +62,7 @@ LightmapSettings:
     m_AOMaxDistance: 1
     m_CompAOExponent: 1
     m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
     m_Padding: 2
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
@@ -77,10 +77,16 @@ LightmapSettings:
     m_PVRDirectSampleCount: 32
     m_PVRSampleCount: 500
     m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
     m_PVRFilterTypeDirect: 0
     m_PVRFilterTypeIndirect: 0
     m_PVRFilterTypeAO: 0
-    m_PVRFilteringMode: 1
+    m_PVREnvironmentMIS: 0
     m_PVRCulling: 1
     m_PVRFilteringGaussRadiusDirect: 1
     m_PVRFilteringGaussRadiusIndirect: 5
@@ -88,7 +94,8 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
-    m_ShowResolutionOverlay: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -113,11 +120,55 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &207413911
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 207413913}
+  - component: {fileID: 207413912}
+  m_Layer: 0
+  m_Name: Tester
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &207413912
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 207413911}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 65e230790caff714fa6f0f0356432286, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &207413913
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 207413911}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 9.16605, y: -0.7460551, z: 1.9061513}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 705507995}
@@ -133,15 +184,17 @@ GameObject:
 Light:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 705507993}
   m_Enabled: 1
-  serializedVersion: 8
+  serializedVersion: 9
   m_Type: 1
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
   m_Intensity: 1
   m_Range: 10
   m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
   m_CookieSize: 10
   m_Shadows:
     m_Type: 2
@@ -151,6 +204,24 @@ Light:
     m_Bias: 0.05
     m_NormalBias: 0.4
     m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
   m_Cookie: {fileID: 0}
   m_DrawHalo: 0
   m_Flare: {fileID: 0}
@@ -158,19 +229,23 @@ Light:
   m_CullingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+  m_RenderingLayerMask: 1
   m_Lightmapping: 1
   m_LightShadowCasterMode: 0
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &705507995
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 705507993}
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
   m_LocalPosition: {x: 0, y: 3, z: 0}
@@ -183,7 +258,8 @@ Transform:
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 963194228}
@@ -200,23 +276,26 @@ GameObject:
 AudioListener:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 963194225}
   m_Enabled: 1
 --- !u!20 &963194227
 Camera:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 963194225}
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 1
   m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
   m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_GateFitMode: 2
   m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
@@ -248,7 +327,8 @@ Camera:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 963194225}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1, z: -10}

--- a/Assets/Scripts/Facu.meta
+++ b/Assets/Scripts/Facu.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1336e140a72b17f4ea3123d6ad632317
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Facu/PaletteManager.cs
+++ b/Assets/Scripts/Facu/PaletteManager.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+public static class PaletteManager
+{
+    public static void CreatePalette(string paletteName)
+    {
+        string path = string.Format("Assets/Resources/Palettes/{0}.asset", paletteName);
+
+        AssetDatabase.CreateAsset(
+            ScriptableObject.CreateInstance<PaletteObject>()
+            .SetName(paletteName), path);
+    }
+
+    public static void DeletePalette(string paletteName)
+    {
+        string path = string.Format("Assets/Resources/Palettes/{0}.asset", paletteName);
+        AssetDatabase.DeleteAsset(path);
+    }
+
+    //TODO: establecer checks en caso de que no esté la carpeta
+    public static PaletteObject LoadPalette(string paletteName)
+    {
+        return Resources.Load<PaletteObject>("Palettes/" + paletteName);
+    }
+
+    public static PaletteObject LoadPalette(string paletteName, string path)
+    {
+        return (PaletteObject)AssetDatabase.LoadAssetAtPath(path + paletteName, typeof(PaletteObject));
+    }
+}

--- a/Assets/Scripts/Facu/PaletteManager.cs.meta
+++ b/Assets/Scripts/Facu/PaletteManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a31e509ddf6d40c48acac7122ee6ae41
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Facu/PaletteObject.cs
+++ b/Assets/Scripts/Facu/PaletteObject.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(fileName ="NewPalette", menuName ="LevelEditor/NewPalette")]
+public class PaletteObject : ScriptableObject
+{
+    public List<GameObject> content = new List<GameObject>();
+    public string paletteName;
+
+    public PaletteObject SetName(string name)
+    {
+        this.paletteName = name;
+        return this;
+    }
+
+    public void AddObject(GameObject gameObject)
+    {
+        if (content.Contains(gameObject))
+            return;
+        content.Add(gameObject);
+    }
+
+    public void RemoveObject(GameObject gameObject)
+    {
+        if (content.Contains(gameObject))
+            return;
+        content.Remove(gameObject);
+    }
+}

--- a/Assets/Scripts/Facu/PaletteObject.cs.meta
+++ b/Assets/Scripts/Facu/PaletteObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 71260934f5d4f6645adbec10fae4570c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Facu/SaveTester.cs
+++ b/Assets/Scripts/Facu/SaveTester.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SaveTester : MonoBehaviour
+{
+    void Start()
+    {
+        PaletteManager.DeletePalette("NewPalette");
+    }
+}

--- a/Assets/Scripts/Facu/SaveTester.cs.meta
+++ b/Assets/Scripts/Facu/SaveTester.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 65e230790caff714fa6f0f0356432286
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Agregados un manager in un SO para guardar y cargar info de las paletas.
Los metodos son los siguientes:
PaletteObject:
- SetName
- AddObject (agrega un objeto a la paleta si no está ya agregado)
-RemoveObject (quita un objeto de la paleta si existe)
(tambien se pueden crear paletas con click derecho Create>LevelEditor>NewPalette)
PaletteManager:
- CreatePalette (Crea un palette con el nombre dado en Resources/Palettes)
- DeletPalette
- LoadPalette (Carga un palette con el nombre dado de la carpeta de recursos, tambien tiene un overload para cargar palettes de otros paths)